### PR TITLE
Move heif to an extra dependency

### DIFF
--- a/DECIMER/config.py
+++ b/DECIMER/config.py
@@ -9,8 +9,8 @@ import io
 import cv2
 import pystow
 import pathlib
-import pyheif
 import zipfile
+
 
 TARGET_DTYPE = tf.float32
 
@@ -93,6 +93,9 @@ def HEIF_to_pillow(image_path: str):
     ___
     Output: PIL.Image
     """
+    
+    import pyheif
+
     heif_file = pyheif.read(image_path)
     pil_im = Image.frombytes(
         heif_file.mode,

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install in development mode with:
 ```shell
 $ git clone https://github.com/Kohulan/DECIMER-Image_Transformer.git decimer
 $ cd decimer/
-$ pip install -e.
+$ pip install -e .
 ```
 - Where `-e` means "editable" mode.
 
@@ -71,6 +71,23 @@ Install from PyPi
 ```shell
 $ pip install decimer
 ```
+
+#### HEIF support
+
+.heic images are supported by the pyheif package, but this is difficult to install on windows, so is not installed by default. To install with heif support:
+
+```shell
+$ pip install -e .[heif]
+```
+
+for an editable install, or
+
+```shell
+$ pip install decimer[heif]
+```
+
+to install from PyPi.
+
 ### How to use inside your own python script
 ```python
 from DECIMER import predict_SMILES

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,11 @@ setuptools.setup(
         "tensorflow==2.10.1",
         "opencv-python",
         "pystow",
-        "pyheif",
         "efficientnet",
     ],
+    install_extras={
+        "heif": ["pyheif"],
+    },
     package_data={"DECIMER": ["repack/*.*", "efficientnetv2/*.*", "Utils/*.*"]},
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
pyheif is difficult to install & poorly supported on windows - several of our team are stuck on old versions because of this dependency and the requirements of our environment.

To resolve this, I'm proposing to move pyheif as an "extra", which will not be installed by default, and can be optionally installed with, e.g

pip install decimer[heif]
