### PR TITLE
Feat  automated pypi releases

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -1,0 +1,25 @@
+name: Publish Python distributions to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install pypa/setuptools
+      run: python -m pip install wheel
+    - name: Build a binary wheel
+      run: python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.DECIMER_PYPI_TOKEN }}

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           release-type: python
           package-name: release-please-action
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           start-version: '2.3.0'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ opencv-python
 pystow
 efficientnet
 pillow_heif
+pyyaml


### PR DESCRIPTION
@Kohulan 

This PR introduces automated Pypi package releases whenever release-please (or a human) publishes a release in this repository. To make this work, two things need to be done:
- Go to https://pypi.org/manage/account/token/ and create a token that has access to the DECIMER Image Transformer Pypi repository. Add this token as a secret with the name `DECIMER_PYPI_TOKEN` to this GitHub repository.
- Go to https://github.com/settings/tokens and create a personal access token with the scopes `repo` and `workflows`. Add this token as a secret with the name `RELEASE_PLEASE_TOKEN` to the repository. This is necessary because any workflow that is triggered using the `GITHUB_TOKEN` cannot trigger subsequent workflows. Consequently, a personal access token needs to be used to trigger the Pypi-release workflow. 

Otto