### PR TITLE
fix: Remove tensorflow_addons dependency to hide deprecation warning

### DIFF
--- a/DECIMER/efficientnetv2/utils.py
+++ b/DECIMER/efficientnetv2/utils.py
@@ -19,7 +19,6 @@ import os
 from absl import logging
 import numpy as np
 import tensorflow as tf
-import tensorflow_addons.layers as tfa_layers
 
 from tensorflow.python.tpu import (
     tpu_function,
@@ -236,7 +235,7 @@ def normalization(
 ):
     """Normalization after conv layers."""
     if norm_type == "gn":
-        return tfa_layers.GroupNormalization(groups, axis, epsilon, name=name)
+        return tf.keras.layers.GroupNormalization(groups, axis, epsilon, name=name)
 
     if norm_type == "tpu_bn":
         return TpuBatchNormalization(

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
         "efficientnet",
         "selfies",
         "pyyaml",
-        "tensorflow-addons",
     ],
     package_data={"DECIMER": ["repack/*.*", "efficientnetv2/*.*", "Utils/*.*"]},
     classifiers=[


### PR DESCRIPTION
When importing the latest version of decimer, the following warning is displayed (see [Colab Example](https://colab.research.google.com/drive/1DORKMygxmPU4b8o-cEewTsZMSO0FiFNT?usp=sharing)): 
```
/usr/local/lib/python3.10/dist-packages/tensorflow_addons/utils/tfa_eol_msg.py:23: UserWarning: 

TensorFlow Addons (TFA) has ended development and introduction of new features.
TFA has entered a minimal maintenance and release mode until a planned end of life in May 2024.
Please modify downstream libraries to take dependencies from other repositories in our TensorFlow community (e.g. Keras, Keras-CV, and Keras-NLP). 

For more information see: https://github.com/tensorflow/addons/issues/2807 
```

Since decimer only uses `tensorflow_addons.GroupNormalization` which has been integrated into tf.keras with v2.11.0 (`tensorflow.keras.layers.GroupNormalization`), i suggest removing this dependency entirely.