### PR TITLE
chore: update TensorFlow compatibility to 2.15.1 and set DECIMER version to 2.7.1 in descriprion

### DIFF
--- a/DECIMER/__init__.py
+++ b/DECIMER/__init__.py
@@ -19,7 +19,7 @@ For comments, bug reports or feature ideas,
 please raise a issue on the Github repository.
 """
 
-__version__ = "2.6.0"
+__version__ = "2.7.1"
 
 __all__ = [
     "DECIMER",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ opencv-python
 pillow-heif
 pre-commit
 pystow
-tensorflow>=2.8.0,<=2.15.0
+tensorflow>=2.8.0,<=2.15.1

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ import setuptools
 if (
     platform.processor() == "arm" or platform.processor() == "i386"
 ) and platform.system() == "Darwin":
-    tensorflow_os = "tensorflow-macos>=2.10.0,<=2.15.0"
+    tensorflow_os = "tensorflow-macos>=2.10.0,<=2.15.1"
 else:
-    tensorflow_os = "tensorflow>=2.12.0,<=2.15.0"
+    tensorflow_os = "tensorflow>=2.12.0,<=2.15.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -20,7 +20,7 @@ setuptools.setup(
     author_email="kohulan.rajan@uni-jena.de",
     maintainer="Kohulan Rajan, Otto Brinkhaus ",
     maintainer_email="kohulan.rajan@uni-jena.de, otto.brinkhaus@uni-jena.de",
-    description="DECIMER 2.6.0: Deep Learning for Chemical Image Recognition using Efficient-Net V2 + Transformer",
+    description="DECIMER 2.7.1: Deep Learning for Chemical Image Recognition using Efficient-Net V2 + Transformer",
     long_description=long_description,
     long_description_content_type="text/markdown",
     entry_points={
@@ -47,6 +47,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
### This PR updates the TensorFlow dependency constraints and fixed the DECIMER version:

1. Extended TensorFlow compatibility to support version 2.15.1 (previously capped at 2.15.0)
   - Updated in requirements.txt
   - Updated in setup.py for both standard Linux/Windows installations and Apple Silicon (M1/M2/M3) Macs

2. Fixed DECIMER version from 2.6.0 to 2.7.1
   - Updated version in __init__.py
   - Updated version in package description

3. Added Python 3.11 to the list of supported Python versions in setup.py